### PR TITLE
add LPRange.fromPadRange to replace missing copyRange function

### DIFF
--- a/classes/Launchpad.sc
+++ b/classes/Launchpad.sc
@@ -90,7 +90,7 @@ Launchpad{
 		//tty=if(fy>=(ty?0),{fy+1},{ty+1s});
 		ttx=tx?fx;
 		tty=ty?fy;
-		^LPRange(pads.copyRange(fx,fy,ttx,tty));
+		^LPRange.fromPadRange(pads,fx,fy,ttx,tty);
 	}
 	//simply set LEDs
 	*setLED{|x,y,val|
@@ -122,6 +122,16 @@ Launchpad{
 
 LPRange{
 	var <>pads;
+	*fromPadRange{|p, fx, fy, tx, ty|
+		var newPads = Array2D.new;
+		(fx..fy).do{|f, fi|
+			(tx..ty).do{|t, ti|
+				newPads.put(fi, ti, p.at(f, t));
+			};
+		};
+		LPRange(newPads);
+	}
+
 	*new{|b|
 		^super.new.init(b);
 	}
@@ -133,7 +143,7 @@ LPRange{
 		ttx=tx?fx;
 		tty=ty?fy;
 		"ERROR: IS THIS BEFORE THE ERROR".debug(\before_copy);
-		out=LPRange(pads.copyRange(fx,fy,ttx,tty).debug(\copiedrange));
+		out=LPRange.fromPadRange(pads,fx,fy,ttx,tty).debug(\copiedrange);
 		"ERROR: IS THIS AFTER THE ERROR".debug(\after_copy);
 		^out;
 	}

--- a/classes/Launchpad.sc
+++ b/classes/Launchpad.sc
@@ -123,13 +123,13 @@ Launchpad{
 LPRange{
 	var <>pads;
 	*fromPadRange{|p, fx, fy, tx, ty|
-		var newPads = Array2D.new;
-		(fx..fy).do{|f, fi|
-			(tx..ty).do{|t, ti|
-				newPads.put(fi, ti, p.at(f, t));
+		var newPads = Array2D.new(1 + (ty - fy), 1 + (tx - fx));
+		(fx..tx).do{|x, xi|
+			(fy..ty).do{|y, yi|
+				newPads.put(yi, xi, p.at(x, y));
 			};
 		};
-		LPRange(newPads);
+		^LPRange.new(newPads);
 	}
 
 	*new{|b|

--- a/classes/Launchpad.sc
+++ b/classes/Launchpad.sc
@@ -123,10 +123,10 @@ Launchpad{
 LPRange{
 	var <>pads;
 	*fromPadRange{|p, fx, fy, tx, ty|
-		var newPads = Array2D.new(1 + (ty - fy), 1 + (tx - fx));
+		var newPads = Array2D.new(1 + (tx - fx), 1 + (ty - fy));
 		(fx..tx).do{|x, xi|
 			(fy..ty).do{|y, yi|
-				newPads.put(yi, xi, p.at(x, y));
+				newPads.put(xi, yi, p.at(x, y));
 			};
 		};
 		^LPRange.new(newPads);


### PR DESCRIPTION
Hi, I was trying out this neat quark, but couldn't get it to work at first. I found out that it was trying to call `pads.copyRange` when `pads` is an `Array2D`. It seems that function doesn't exist on `Array2D`. I saw this function was really only used twice, so I added a static factory function on `LPRange` that generates the sub-range manually, and replaced those calls with it.

I'm pretty new to supercollider, so hopefully it's in line with proper ways of doing things, but it is working for me (though I've only tried it with a basic `LPPushButton` use case so far). I do think the code could be optimized by initializing the Array2D with the proper size at the start, if that's possible. 

Also, I realize there could just be something wrong with my environment and it's not really a bug, but I noticed some debug messages around one `pads.copyRange` call (which I left alone), so I figured I was not the only one to encounter it.